### PR TITLE
213.* IDE compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,14 +88,14 @@ sourceSets {
 }
 
 def intellijSinceBuild = '211.6693'
-def intellijUntilBuild = '212.*'
+def intellijUntilBuild = '213.*'
 
 patchPluginXml {
     sinceBuild intellijSinceBuild
     untilBuild intellijUntilBuild
     changeNotes """
     <ul>
-        <li>Compatibility with 212.* IDEs</li>
+        <li>Compatibility with 213.* IDEs</li>
     </ul>
     """
 }

--- a/src/main/java/com/google/idea/gn/psi/reference/GnCallIdentifierReference.kt
+++ b/src/main/java/com/google/idea/gn/psi/reference/GnCallIdentifierReference.kt
@@ -30,7 +30,7 @@ class GnCallIdentifierReference(val call: GnCall) : PsiReferenceBase<PsiElement?
             // Template and import calls must be executed so they show up in the scope.
             function is Template ||
                 function is Import -> Visitor.CallAction.EXECUTE
-            this@GnCallIdentifierReference.call.parents()
+            this@GnCallIdentifierReference.call.parents(true)
                 .contains(call) -> Visitor.CallAction.VISIT_BLOCK
             else -> Visitor.CallAction.SKIP
           }


### PR DESCRIPTION
- Add 213.* IDE compatibility
- Replacing deprecated method call in `GnCallIdentifierReference.kt`

Note. PR #16 also needed to reduce warnings.