### PR TITLE
Add 221.* IDE compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -102,14 +102,14 @@ test {
 }
 
 def intellijSinceBuild = '211.6693'
-def intellijUntilBuild = '213.*'
+def intellijUntilBuild = '221.*'
 
 patchPluginXml {
     sinceBuild.set(intellijSinceBuild)
     untilBuild.set(intellijUntilBuild)
     changeNotes.set("""
     <ul>
-        <li>Compatibility with 213.* IDEs</li>
+        <li>Compatibility with 221.* IDEs</li>
     </ul>
     """)
 }


### PR DESCRIPTION
I didn't update any other dependencies, and I just modified this as shown here and tried to build. And I've been using this on CLion 2022.1 for a few days.
So far, it works as expected.