### PR TITLE
Change the format of version to distinguish release and snapshot versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import org.jetbrains.grammarkit.tasks.GenerateLexerTask
 import org.jetbrains.grammarkit.tasks.GenerateParserTask
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmCompile
 
-val gitVersion: groovy.lang.Closure<String> by extra
+val versionDetails: groovy.lang.Closure<com.palantir.gradle.gitversion.VersionDetails> by extra
 
 plugins {
     id("java")
@@ -12,7 +12,15 @@ plugins {
     alias(libs.plugins.gitVersion)
 }
 
-version = gitVersion()
+val gitDetails = versionDetails()
+version = if (gitDetails.isCleanTag) {
+    gitDetails.version
+} else {
+    // eg. 0.1.4-dev.12345678
+    providers.gradleProperty("intellijGnVersion").get().ifEmpty {
+        throw IllegalStateException("intellijGnVersion must be set in gradle.properties")
+    } + "-dev." + gitDetails.gitHash
+}
 
 java.sourceCompatibility = JavaVersion.VERSION_11
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,4 @@
+intellijGnVersion = 0.1.4
+
 # Opt-out flag for bundling Kotlin standard library -> https://jb.gg/intellij-platform-kotlin-stdlib
 kotlin.stdlib.default.dependency = false


### PR DESCRIPTION
Release version would be plain version number, like 1.0.0, and snapshot version contains "-dev" and git commit hash, so it would be much easier to distinguish them.