### PR TITLE
Use Java 17 for building on Github Action.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: zulu
-          java-version: 11
+          java-version: 17
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: zulu
-          java-version: 11
+          java-version: 17
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2


### PR DESCRIPTION
While Java 11 is sufficient to use Gradle, GrammarKit v2022.1 requires Java 17 [1] for building. Note that we still create Java 11 compatible bytecode, since IntelliJ 2022.1 requires Java 11.

[1] https://github.com/JetBrains/Grammar-Kit/commit/59a1d1208b1c0e005b48f3748ba5aef49f3be0e3