### PR TITLE
Set untilBuild as empty

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -106,9 +106,11 @@ tasks.withType<Test> {
 }
 
 val intellijSinceBuild = "221"
+val intellijUntilBuild = ""
 
 tasks.patchPluginXml {
     sinceBuild = intellijSinceBuild
+    untilBuild = intellijUntilBuild
     val changelog = project.changelog // local variable for configuration cache compatibility
     // Get the latest available change notes from the changelog file
     changeNotes = providers.gradleProperty("intellijGnVersion").map { pluginVersion ->


### PR DESCRIPTION
In 54764f1f8ae6d78ac87eea689d6dfff6012fb558, we unset untilBuild in order to avoid specifying the maximum supported IntelliJ version. However, unsetting untilBuild makes the plugin only compatible with the version specified in sinceBuild. In other words, current tree is only compatible with 2021.1.

Fix it by setting untilBuild as an empty string.