### PR TITLE
Implement AbstractElementManipulator of GnStringExprImpl to not crash…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,5 @@
 ### Changed
 
 - Change minimum supported IntelliJ version to 2022.1
+- Implement AbstractElementManipulator of GnStringExprImpl to not crash on
+  rename refactoring 

--- a/src/main/java/com/google/idea/gn/manipulators/GnStringExprManipulator.kt
+++ b/src/main/java/com/google/idea/gn/manipulators/GnStringExprManipulator.kt
@@ -1,0 +1,23 @@
+package com.google.idea.gn.manipulators
+
+import com.google.idea.gn.psi.impl.GnStringExprImpl
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.AbstractElementManipulator
+
+
+class GnStringExprManipulator : AbstractElementManipulator<GnStringExprImpl>() {
+    override fun handleContentChange(
+        element: GnStringExprImpl,
+        range: TextRange,
+        newContent: String?
+    ): GnStringExprImpl? {
+        // TODO: Implement this
+        LOG.warn("Renaming GN Expression is currently not supported")
+        return null
+    }
+
+    companion object {
+        private val LOG = logger<GnStringExprManipulator>()
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -48,6 +48,8 @@
         language="gn"/>
     <lang.formatter language="gn"
         implementationClass="com.google.idea.gn.GnFormattingBuilder"/>
+    <lang.elementManipulator forClass="com.google.idea.gn.psi.impl.GnStringExprImpl"
+                             implementationClass="com.google.idea.gn.manipulators.GnStringExprManipulator"/>
     <enterBetweenBracesDelegate implementationClass="com.google.idea.gn.GnEnterDelegate"
         language="gn"/>
     <colorSettingsPage implementation="com.google.idea.gn.GnColorSettingsPage"/>


### PR DESCRIPTION
… on rename

Currently, when a file that is referenced in GN is renamed, the IDE crashes. This is because AbstractElementManipulator is not implemented for GnStringExprImpl, which is the PSI element that represents a string literal in GN.
This commit implements the method, which allows IntelliJ to rename strings in GN files. However, this is a workaround, as the string literal is not actually renamed in the GN file. Future work will be needed to implement this functionality.