### PR TITLE
Use gradle/actions/wrapper-validation instead of gradle/wrapper-validation-action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - uses: gradle/wrapper-validation-action@v2.1.2
+      - uses: gradle/actions/wrapper-validation@v3.3.1
 
       - uses: actions/setup-java@v4
         with:


### PR DESCRIPTION
The latter is deprecated.